### PR TITLE
Add Solgaleo 3D scene with video backdrop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,107 @@
-placeholder
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Solgaleo Showcase</title>
+  <style>
+    html, body {
+      margin: 0;
+      height: 100%;
+      overflow: hidden;
+    }
+    #bgVideo {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      z-index: -1;
+    }
+    canvas {
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <video id="bgVideo" autoplay muted loop playsinline>
+    <source src="public/background.webm" type="video/webm" />
+  </video>
+  <script type="module">
+    import * as THREE from 'https://unpkg.com/three@0.159.0/build/three.module.js';
+    import { GLTFLoader } from 'https://unpkg.com/three@0.159.0/examples/jsm/loaders/GLTFLoader.js';
+    import { EffectComposer } from 'https://unpkg.com/three@0.159.0/examples/jsm/postprocessing/EffectComposer.js';
+    import { RenderPass } from 'https://unpkg.com/three@0.159.0/examples/jsm/postprocessing/RenderPass.js';
+    import { UnrealBloomPass } from 'https://unpkg.com/three@0.159.0/examples/jsm/postprocessing/UnrealBloomPass.js';
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.set(0, 1.5, 5);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(5, 10, 7.5);
+    scene.add(light);
+
+    const loader = new GLTFLoader();
+    let solgaleo;
+    loader.load('public/solgaleo/solgaleo.glb', (gltf) => {
+      solgaleo = gltf.scene;
+
+      // Scale model to reasonable size
+      const box = new THREE.Box3().setFromObject(solgaleo);
+      const size = box.getSize(new THREE.Vector3()).length();
+      const scale = 2 / size;
+      solgaleo.scale.setScalar(scale);
+
+      // subtle emissive glow
+      solgaleo.traverse((child) => {
+        if (child.isMesh && child.material && 'emissive' in child.material) {
+          child.material.emissive = new THREE.Color(0xffddaa);
+          child.material.emissiveIntensity = 0.4;
+        }
+      });
+
+      scene.add(solgaleo);
+    });
+
+    // Post-processing for bloom effect
+    const composer = new EffectComposer(renderer);
+    composer.addPass(new RenderPass(scene, camera));
+    const bloom = new UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 1.5, 0.4, 0.85);
+    composer.addPass(bloom);
+
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      composer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    const clock = new THREE.Clock();
+
+    function animate() {
+      requestAnimationFrame(animate);
+      const t = clock.getElapsedTime();
+
+      if (solgaleo) {
+        // Floating motion
+        solgaleo.position.y = Math.sin(t) * 0.2;
+
+        // Camera slowly orbiting around the model
+        const radius = 5;
+        camera.position.x = Math.sin(t * 0.2) * radius;
+        camera.position.z = Math.cos(t * 0.2) * radius;
+        camera.lookAt(solgaleo.position);
+      }
+
+      composer.render();
+    }
+
+    animate();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Render looping background video
- Load Solgaleo GLB with floating animation and orbiting camera
- Apply bloom-based glow around model

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae08d3643c832489ad28d13f82e4f8