### PR TITLE
feat: add fallback model paths

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,34 +51,47 @@
 
     const loader = new GLTFLoader();
     let solgaleo;
-    loader.load(
-      'solgaleo/solgaleo.glb',
-      (gltf) => {
-        solgaleo = gltf.scene;
+    const modelPaths = ['./solgaleo/solgaleo.glb', './solgaleo/gltf/scene.gltf'];
 
-        // Scale model to reasonable size and center it
-        const box = new THREE.Box3().setFromObject(solgaleo);
-        const size = box.getSize(new THREE.Vector3()).length();
-        const scale = 2 / size;
-        solgaleo.scale.setScalar(scale);
+    function loadModel(index = 0) {
+      if (index >= modelPaths.length) {
+        console.error('Failed to load model');
+        return;
+      }
+      loader.load(
+        modelPaths[index],
+        (gltf) => {
+          solgaleo = gltf.scene;
 
-        box.setFromObject(solgaleo);
-        const center = box.getCenter(new THREE.Vector3());
-        solgaleo.position.sub(center);
+          // Scale model to reasonable size and center it
+          const box = new THREE.Box3().setFromObject(solgaleo);
+          const size = box.getSize(new THREE.Vector3()).length();
+          const scale = 2 / size;
+          solgaleo.scale.setScalar(scale);
 
-        // subtle emissive glow
-        solgaleo.traverse((child) => {
-          if (child.isMesh && child.material && 'emissive' in child.material) {
-            child.material.emissive = new THREE.Color(0xffddaa);
-            child.material.emissiveIntensity = 0.4;
-          }
-        });
+          box.setFromObject(solgaleo);
+          const center = box.getCenter(new THREE.Vector3());
+          solgaleo.position.sub(center);
 
-        scene.add(solgaleo);
-      },
-      undefined,
-      (err) => console.error('Failed to load model', err)
-    );
+          // subtle emissive glow
+          solgaleo.traverse((child) => {
+            if (child.isMesh && child.material && 'emissive' in child.material) {
+              child.material.emissive = new THREE.Color(0xffddaa);
+              child.material.emissiveIntensity = 0.4;
+            }
+          });
+
+          scene.add(solgaleo);
+        },
+        undefined,
+        (err) => {
+          console.warn(`Failed to load model at ${modelPaths[index]}`, err);
+          loadModel(index + 1);
+        }
+      );
+    }
+
+    loadModel();
 
     // Post-processing for bloom effect
     const composer = new EffectComposer(renderer);


### PR DESCRIPTION
## Summary
- try loading Solgaleo from multiple model paths

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server 8000` served index and model files


------
https://chatgpt.com/codex/tasks/task_e_68ae0fcf2f5c8324953ba60b2e0523a5