### PR TITLE
Add fallback model path for Solgaleo viewer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,7 @@
 
     const loader = new GLTFLoader();
     let solgaleo;
-    const modelPaths = ['solgaleo/solgaleo.glb'];
+    const modelPaths = ['./solgaleo/solgaleo.glb', './solgaleo/gltf/scene.gltf'];
 
     function loadModel(index) {
       if (index >= modelPaths.length) return;


### PR DESCRIPTION
## Summary
- Load Solgaleo model from either `solgaleo.glb` or `gltf/scene.gltf`

## Testing
- `npm test` *(fails: enoent package.json)*
- `python3 -m http.server 8000 --directory public` then `curl -I http://localhost:8000/`


------
https://chatgpt.com/codex/tasks/task_e_68ae11d795108324898d808f8e13ae64