### PR TITLE
Add random Solgaleo animations with orbit controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,7 @@
     import { EffectComposer } from 'https://unpkg.com/three@0.159.0/examples/jsm/postprocessing/EffectComposer.js';
     import { RenderPass } from 'https://unpkg.com/three@0.159.0/examples/jsm/postprocessing/RenderPass.js';
     import { UnrealBloomPass } from 'https://unpkg.com/three@0.159.0/examples/jsm/postprocessing/UnrealBloomPass.js';
+    import { OrbitControls } from 'https://unpkg.com/three@0.159.0/examples/jsm/controls/OrbitControls.js';
 
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
@@ -51,7 +52,15 @@
 
     const loader = new GLTFLoader();
     let solgaleo;
-    const modelPaths = ['./solgaleo/solgaleo.glb', './solgaleo/gltf/scene.gltf'];
+    let mixer;
+    let actions = [];
+    let activeAction;
+    const clipNames = ['solgaleo_idle', 'solgaleo_run', 'solgaleo_attack1', 'solgaleo_attack2'];
+    const modelPaths = [
+      './solgaleo/solgaleo2/source/model.gltf',
+      './solgaleo/solgaleo.glb',
+      './solgaleo/gltf/scene.gltf'
+    ];
 
     function loadModel(index) {
       if (index >= modelPaths.length) return;
@@ -78,6 +87,30 @@
             }
           });
 
+          // Setup animations
+          mixer = new THREE.AnimationMixer(solgaleo);
+          actions = clipNames
+            .map((name) => THREE.AnimationClip.findByName(gltf.animations, name))
+            .filter(Boolean)
+            .map((clip) => {
+              const action = mixer.clipAction(clip);
+              action.clampWhenFinished = true;
+              return action;
+            });
+
+          function playRandomAnimation() {
+            if (!actions.length) return;
+            const next = actions[Math.floor(Math.random() * actions.length)];
+            if (activeAction) {
+              activeAction.fadeOut(0.3);
+            }
+            activeAction = next;
+            activeAction.reset().fadeIn(0.3).play();
+          }
+
+          mixer.addEventListener('finished', playRandomAnimation);
+          playRandomAnimation();
+
           scene.add(solgaleo);
         },
         undefined,
@@ -93,8 +126,19 @@
     // Post-processing for bloom effect
     const composer = new EffectComposer(renderer);
     composer.addPass(new RenderPass(scene, camera));
-    const bloom = new UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 1.5, 0.4, 0.85);
+    const bloom = new UnrealBloomPass(
+      new THREE.Vector2(window.innerWidth, window.innerHeight),
+      1.5,
+      0.4,
+      0.85
+    );
     composer.addPass(bloom);
+
+    // Controls for panning/orbiting
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.autoRotate = true;
+    controls.autoRotateSpeed = 0.2;
 
     window.addEventListener('resize', () => {
       camera.aspect = window.innerWidth / window.innerHeight;
@@ -107,19 +151,19 @@
 
     function animate() {
       requestAnimationFrame(animate);
+      const delta = clock.getDelta();
       const t = clock.getElapsedTime();
 
       if (solgaleo) {
         // Floating motion
         solgaleo.position.y = Math.sin(t) * 0.2;
-
-        // Camera slowly orbiting around the model
-        const radius = 5;
-        camera.position.x = Math.sin(t * 0.2) * radius;
-        camera.position.z = Math.cos(t * 0.2) * radius;
-        camera.lookAt(solgaleo.position);
       }
 
+      if (mixer) {
+        mixer.update(delta);
+      }
+
+      controls.update();
       composer.render();
     }
 


### PR DESCRIPTION
## Summary
- Load the original Solgaleo glTF with animation clips
- Play idle, run and attack animations in random order
- Enable orbit controls so the camera auto-pans around the model

## Testing
- `npx --yes serve -s public` *(fails: npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e342634832496f6c2de8c67c39a