### PR TITLE
Add Japanese logo under main Solgaleo logo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,13 +52,13 @@
       align-items: center;
     }
     #logo {
-      width: 30%;
+      width: 37.5%;
       height: auto;
       display: block;
       animation: glow 4s linear infinite;
     }
     #logo-jp {
-      width: 27%;
+      width: 33.75%;
       height: auto;
       margin-top: 10px;
       display: block;

--- a/public/index.html
+++ b/public/index.html
@@ -52,13 +52,13 @@
       align-items: center;
     }
     #logo {
-      width: 37.5%;
+      width: 46.875%;
       height: auto;
       display: block;
       animation: glow 4s linear infinite;
     }
     #logo-jp {
-      width: 33.75%;
+      width: 42.1875%;
       height: auto;
       margin-top: 10px;
       display: block;

--- a/public/index.html
+++ b/public/index.html
@@ -42,13 +42,25 @@
       z-index: 1;
       text-align: center;
     }
-    #logo {
+    #logo-wrapper {
       position: absolute;
       bottom: 20px;
       left: 50%;
       transform: translateX(-50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    #logo {
       width: 30%;
       height: auto;
+      display: block;
+      animation: glow 4s linear infinite;
+    }
+    #logo-jp {
+      width: 27%;
+      height: auto;
+      margin-top: 10px;
       display: block;
       animation: glow 4s linear infinite;
     }
@@ -93,7 +105,10 @@
     <audio id="bgAudio" src="pokemonmusic.mp3" autoplay loop preload="auto" playsinline></audio>
     <button id="muteBtn">Mute</button>
     <div id="model-container">
-      <img src="Solgaleo Logo.png" alt="Solgaleo logo" id="logo" />
+      <div id="logo-wrapper">
+        <img src="Solgaleo Logo.png" alt="Solgaleo logo" id="logo" />
+        <img src="japaneselogo.svg" alt="Japanese Solgaleo logo" id="logo-jp" />
+      </div>
     </div>
     <section id="card-section">
       <img src="card.png" alt="card" id="card" />


### PR DESCRIPTION
## Summary
- Introduce a `logo-wrapper` to position Solgaleo logo and a smaller Japanese variant stacked at bottom of model container
- Style new `logo-jp` at 27% width with glow animation beneath main logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af14bed8a0832496fb0f0623f0feb1